### PR TITLE
Change API; tweak masks and vessels to match regular splits

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -859,37 +859,41 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.Pantheon5Entry: shouldSplit = nextScene.StartsWith("GG_Vengefly_V") && nextScene != sceneName; break;
 
                 case SplitName.OnObtainGhostMarissa:
-                    shouldSplit = store.CheckIncreased(Offset.dreamOrbs) && sceneName == "Ruins_Bathhouse";
+                    shouldSplit = store.CheckIncremented(Offset.dreamOrbs) && sceneName == "Ruins_Bathhouse";
                     break;
                 case SplitName.OnObtainGhostCaelifFera:
-                    shouldSplit = store.CheckIncreased(Offset.dreamOrbs) && sceneName == "Fungus1_24";
+                    shouldSplit = store.CheckIncremented(Offset.dreamOrbs) && sceneName == "Fungus1_24";
                     break;
                 case SplitName.OnObtainGhostPoggy:
-                    shouldSplit = store.CheckIncreased(Offset.dreamOrbs) && sceneName == "Ruins_Elevator";
+                    shouldSplit = store.CheckIncremented(Offset.dreamOrbs) && sceneName == "Ruins_Elevator";
                     break;
                 case SplitName.OnObtainGhostGravedigger:
-                    shouldSplit = store.CheckIncreased(Offset.dreamOrbs) && sceneName == "Town";
+                    shouldSplit = store.CheckIncremented(Offset.dreamOrbs) && sceneName == "Town";
                     break;
                 case SplitName.OnObtainGhostJoni:
-                    shouldSplit = store.CheckIncreased(Offset.dreamOrbs) && sceneName == "Cliffs_05";
+                    shouldSplit = store.CheckIncremented(Offset.dreamOrbs) && sceneName == "Cliffs_05";
                     break;
                 case SplitName.OnObtainGhostCloth:
-                    shouldSplit = store.CheckIncreased(Offset.dreamOrbs) && sceneName == "Fungus3_23" && store.TraitorLordDeadOnEntry;
+                    shouldSplit = store.CheckIncremented(Offset.dreamOrbs) && sceneName == "Fungus3_23" && store.TraitorLordDeadOnEntry;
                     break;
                 case SplitName.OnObtainGhostVespa:
-                    shouldSplit = store.CheckIncreased(Offset.dreamOrbs) && sceneName == "Hive_05" && mem.PlayerData<bool>(Offset.gotCharm_29);
+                    shouldSplit = store.CheckIncremented(Offset.dreamOrbs) && sceneName == "Hive_05" && mem.PlayerData<bool>(Offset.gotCharm_29);
                     break;
 
-                case SplitName.OnObtainWanderersJournal: shouldSplit = store.CheckIncreased(Offset.trinket1); break;
-                case SplitName.OnObtainHallownestSeal: shouldSplit = store.CheckIncreased(Offset.trinket2); break;
-                case SplitName.OnObtainKingsIdol: shouldSplit = store.CheckIncreased(Offset.trinket3); break;
-                case SplitName.OnObtainArcaneEgg: shouldSplit = store.CheckIncreased(Offset.trinket4); break;
-                case SplitName.OnObtainRancidEgg: shouldSplit = store.CheckIncreased(Offset.rancidEggs); break;
-                case SplitName.OnObtainMaskShard: shouldSplit = store.CheckChanged(Offset.heartPieces); break;
-                case SplitName.OnObtainVesselFragment: shouldSplit = store.CheckChanged(Offset.vesselFragments); break;
-                case SplitName.OnObtainSimpleKey: shouldSplit = store.CheckIncreased(Offset.simpleKeys); break;
-                case SplitName.OnUseSimpleKey: shouldSplit = store.CheckIncreased(Offset.simpleKeys, -1); break;
-                case SplitName.OnObtainGrub: shouldSplit = store.CheckIncreased(Offset.grubsCollected); break;
+                case SplitName.OnObtainWanderersJournal: shouldSplit = store.CheckIncremented(Offset.trinket1); break;
+                case SplitName.OnObtainHallownestSeal: shouldSplit = store.CheckIncremented(Offset.trinket2); break;
+                case SplitName.OnObtainKingsIdol: shouldSplit = store.CheckIncremented(Offset.trinket3); break;
+                case SplitName.OnObtainArcaneEgg: shouldSplit = store.CheckIncremented(Offset.trinket4); break;
+                case SplitName.OnObtainRancidEgg: shouldSplit = store.CheckIncremented(Offset.rancidEggs); break;
+                case SplitName.OnObtainMaskShard:
+                    shouldSplit = store.CheckIncremented(Offset.maxHealthBase) || (store.CheckIncremented(Offset.heartPieces) && mem.PlayerData<int>(Offset.heartPieces) < 4);
+                    break;
+                case SplitName.OnObtainVesselFragment:
+                    shouldSplit = store.CheckIncreasedBy(Offset.MPReserveMax, 33) || (store.CheckIncremented(Offset.vesselFragments) && mem.PlayerData<int>(Offset.vesselFragments) < 3);
+                    break;
+                case SplitName.OnObtainSimpleKey: shouldSplit = store.CheckIncremented(Offset.simpleKeys); break;
+                case SplitName.OnUseSimpleKey: shouldSplit = store.CheckIncreasedBy(Offset.simpleKeys, -1); break;
+                case SplitName.OnObtainGrub: shouldSplit = store.CheckIncremented(Offset.grubsCollected); break;
             }
 
             if (shouldSplit) store.Update();

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -790,7 +790,7 @@ namespace LiveSplit.HollowKnight {
                         mem.PlayerData<int>(Offset.soldTrinket3) == 4;
                     break;
                 case SplitName.HappyCouplePlayerDataEvent: shouldSplit = mem.PlayerData<bool>(Offset.nailsmithConvoArt); break;
-                case SplitName.GodhomeBench: shouldSplit = sceneName.StartsWith("GG_Spa") && sceneName != nextScene; break;
+                case SplitName.GodhomeBench: shouldSplit = sceneName.StartsWith("GG_Spa") && sceneName != nextScene && !store.SplitThisTransition; break;
                 
                 case SplitName.Menu: shouldSplit = sceneName == "Menu_Title"; break;
                 case SplitName.MenuClaw: shouldSplit = mem.PlayerData<bool>(Offset.hasWallJump); break;
@@ -851,6 +851,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.KilledOblobbles: shouldSplit = mem.PlayerData<int>(Offset.killsOblobble) == 1; break;
                 case SplitName.WhitePalaceEntry: shouldSplit = nextScene.StartsWith("White_Palace_11") && nextScene != sceneName; break;
                 case SplitName.ManualSplit: shouldSplit = false; break;
+                case SplitName.AnyTransition: shouldSplit = nextScene != sceneName && !store.SplitThisTransition; break;
                 case SplitName.WhitePalaceLowerEntry: shouldSplit = nextScene.StartsWith("White_Palace_01") && nextScene != sceneName; break;
                 case SplitName.WhitePalaceLowerOrb: shouldSplit = nextScene.StartsWith("White_Palace_02") && nextScene != sceneName; break;
                 case SplitName.QueensGardensPostArenaTransition: shouldSplit = nextScene.StartsWith("Fungus3_13") && nextScene != sceneName; break;
@@ -896,7 +897,10 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.OnObtainGrub: shouldSplit = store.CheckIncremented(Offset.grubsCollected); break;
             }
 
-            if (shouldSplit) store.Update();
+            if (shouldSplit) {
+                store.SplitThisTransition = true;
+                store.Update();
+            }
             return shouldSplit;
         }
         private void HandleSplit(bool shouldSplit, bool shouldReset = false) {

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -1135,9 +1135,9 @@ namespace LiveSplit.HollowKnight {
         OnObtainArcaneEgg,
         [Description("Rancid Egg (Obtain)"), ToolTip("Splits when obtaining a Rancid Egg")]
         OnObtainRancidEgg,
-        [Description("Mask Shard (Obtain)"), ToolTip("Splits when obtaining a Mask Shard")]
+        [Description("Mask Shard (Obtain)"), ToolTip("Splits when obtaining a Mask Shard (splits on upgrade for full mask)")]
         OnObtainMaskShard,
-        [Description("Vessel Fragment (Obtain)"), ToolTip("Splits when obtaining a Vessel Fragment")]
+        [Description("Vessel Fragment (Obtain)"), ToolTip("Splits when obtaining a Vessel Fragment (splits on upgrade for full vessel)")]
         OnObtainVesselFragment,
         [Description("Simple Key (Obtain)"), ToolTip("Splits when obtaining a Simple Key")]
         OnObtainSimpleKey,

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -1146,6 +1146,8 @@ namespace LiveSplit.HollowKnight {
         [Description("Grub (Obtain)"), ToolTip("Splits when obtaining a Grub")]
         OnObtainGrub,
 
+        [Description("Any Transition (Transition)"), ToolTip("Splits when the knight enters a transition (only one will split per transition)")]
+        AnyTransition,
         [Description("Manual Split (Misc)"), ToolTip("Never splits. Use this when you need to manually split while using ordered splits")]
         ManualSplit,
 

--- a/HollowKnightStoredData.cs
+++ b/HollowKnightStoredData.cs
@@ -16,12 +16,40 @@ namespace LiveSplit.HollowKnight
             return pdInts[offset];
         }
 
-        public bool CheckIncreased(Offset offset, int value = 1) {
+        /// <summary>
+        /// Checks if the PD int given by offset has increased by value (i.e. new - old = value) since the last update
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public bool CheckIncreasedBy(Offset offset, int value) {
             bool ans = mem.PlayerData<int>(offset) == GetValue(offset) + value;
             return ans;
         }
+        /// <summary>
+        /// Checks if the PD int given by offset has increased by 1 since the last update
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        public bool CheckIncremented(Offset offset) {
+            return CheckIncreasedBy(offset, 1);
+        }
+        /// <summary>
+        /// Checks if the PD int given by offset has changed since the last update
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <returns></returns>
         public bool CheckChanged(Offset offset) {
             bool ans = mem.PlayerData<int>(offset) != GetValue(offset);
+            return ans;
+        }
+        /// <summary>
+        /// Checks if the PD int given by offset has increased since the last update
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        public bool CheckIncreased(Offset offset) {
+            bool ans = mem.PlayerData<int>(offset) > GetValue(offset);
             return ans;
         }
 

--- a/HollowKnightStoredData.cs
+++ b/HollowKnightStoredData.cs
@@ -6,6 +6,10 @@ namespace LiveSplit.HollowKnight
 
         private ConcurrentDictionary<Offset, int> pdInts = new ConcurrentDictionary<Offset, int>();
         public bool TraitorLordDeadOnEntry { get; private set; } = false;
+        /// <summary>
+        /// Returns true if the knight is currently in a transition and has already split there
+        /// </summary>
+        public bool SplitThisTransition { get; set; } = false;
 
         private HollowKnightMemory mem;
 
@@ -61,7 +65,13 @@ namespace LiveSplit.HollowKnight
             foreach (Offset offset in pdInts.Keys) {
                 pdInts[offset] = mem.PlayerData<int>(offset);
             }
-            if (mem.HeroTransitionState() != HeroTransitionState.WAITING_TO_TRANSITION) TraitorLordDeadOnEntry = mem.PlayerData<bool>(Offset.killedTraitorLord);
+            if (mem.HeroTransitionState() != HeroTransitionState.WAITING_TO_TRANSITION) {
+                // In transition
+                TraitorLordDeadOnEntry = mem.PlayerData<bool>(Offset.killedTraitorLord);
+            } else {
+                // Not in transition
+                SplitThisTransition = false;
+            }
         }
     }
 }


### PR DESCRIPTION
We now have the following four options:

CheckIncreased (check if the pd int increased by anything this frame)
CheckIncreasedBy (check if the pd int increased by a specific value this frame - can be negative so increased by -1 => decreased by 1)
CheckIncremented (check if increased by 1)
CheckChanged (check if changed)
